### PR TITLE
fix: updates action to use service token

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -140,6 +140,10 @@ jobs:
     needs: [bump_version, publish_server]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.default_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.SERVICE_TOKEN }}
       - name: Pull latest changes
         run: git pull origin main
       - name: Update version


### PR DESCRIPTION
Closes #3 

- Uses the service token to commit the client code to the main branch