### PR TITLE
fix: updates session handlers

### DIFF
--- a/aind-labtracks-service-server/src/aind_labtracks_service_server/handler.py
+++ b/aind-labtracks-service-server/src/aind_labtracks_service_server/handler.py
@@ -72,7 +72,7 @@ class SessionHandler:
             .outerjoin(g, ac.group_id == g.id)
             .outerjoin(gm, m.group_id == gm.id)
         )
-        results = self.session.execute(statement=statement)
+        results = self.session.execute(statement=statement).all()
         subject_models = [Subject.model_validate(r) for r in results]
         return subject_models
 
@@ -116,6 +116,6 @@ class SessionHandler:
             .join(tt, ts.task_type_id == tt.id)
             .join(ap, ts.acuc_link_id == ap.link_index)
         )
-        results = self.session.execute(statement=statement)
+        results = self.session.execute(statement=statement).all()
         task_models = [Task.model_validate(r) for r in results]
         return task_models

--- a/aind-labtracks-service-server/src/aind_labtracks_service_server/session.py
+++ b/aind-labtracks-service-server/src/aind_labtracks_service_server/session.py
@@ -8,7 +8,9 @@ from aind_labtracks_service_server.configs import Settings
 # Settings will be pulled from env
 settings = Settings()
 
-engine = create_engine(url=settings.db_connection_str)
+engine = create_engine(
+    url=settings.db_connection_str, isolation_level="AUTOCOMMIT"
+)
 
 session_local = sessionmaker(
     bind=engine, class_=Session, expire_on_commit=False


### PR DESCRIPTION
Closes #19 
- Adds auto-commit to engine to prevent rollback on read-only endpoints
- Adds .all() to collect results

TODO:
May need to refactor things in the future to remove deprecation warnings and upgrade to latest SQLModel