### PR TITLE
feat: adds iacuc protocol info and death date to subject view

### DIFF
--- a/aind-labtracks-service-server/src/aind_labtracks_service_server/handler.py
+++ b/aind-labtracks-service-server/src/aind_labtracks_service_server/handler.py
@@ -47,6 +47,7 @@ class SessionHandler:
         g = aliased(Groups, name="g")
         gm = aliased(Groups, name="gm")
         s = aliased(Species, name="s")
+        ap = aliased(AcucProtocol, name="ap")
         # PyCharm raises warnings about the usage of the .label method
         # noinspection PyUnresolvedReferences
         statement = (
@@ -55,6 +56,7 @@ class SessionHandler:
                 ac.class_values,
                 ac.sex,
                 ac.birth_date,
+                ac.death_date,
                 s.species_name,
                 ac.cage_id,
                 ac.room_id,
@@ -64,6 +66,8 @@ class SessionHandler:
                 m.class_values.label("maternal_class_values"),
                 g.group_name,
                 gm.group_description.label("group_description"),
+                ap.protocol_number,
+                ap.protocol_title,
             )
             .where(ac.id == subject_id)
             .outerjoin(s, ac.species_id == s.id)
@@ -71,6 +75,7 @@ class SessionHandler:
             .outerjoin(m, ac.maternal_index == m.id)
             .outerjoin(g, ac.group_id == g.id)
             .outerjoin(gm, m.group_id == gm.id)
+            .outerjoin(ap, ac.acuc_link_id == ap.link_index)
         )
         results = self.session.execute(statement=statement).all()
         subject_models = [Subject.model_validate(r) for r in results]

--- a/aind-labtracks-service-server/src/aind_labtracks_service_server/models.py
+++ b/aind-labtracks-service-server/src/aind_labtracks_service_server/models.py
@@ -587,6 +587,7 @@ class Subject(SQLModel):
     class_values: Optional[MouseCustomClass] = Field(default=None)
     sex: Optional[str] = Field(default=None)
     birth_date: Optional[datetime] = Field(default=None)
+    death_date: Optional[datetime] = Field(default=None)
     species_name: Optional[str] = Field(default=None)
     cage_id: Optional[Decimal] = Field(default=None)
     room_id: Optional[Decimal] = Field(default=None)
@@ -596,6 +597,8 @@ class Subject(SQLModel):
     maternal_class_values: Optional[MouseCustomClass] = Field(default=None)
     group_name: Optional[str] = Field(default=None)
     group_description: Optional[str] = Field(default=None)
+    protocol_number: Optional[str] = Field(default=None)
+    protocol_title: Optional[str] = Field(default=None)
 
     # noinspection PyNestedDecorators
     @field_validator(

--- a/aind-labtracks-service-server/tests/conftest.py
+++ b/aind-labtracks-service-server/tests/conftest.py
@@ -49,6 +49,7 @@ def test_labtracks_subject():
         ),
         sex="F",
         birth_date=datetime(2022, 5, 1, 0, 0),
+        death_date=datetime(2022, 10, 14, 0, 0),
         species_name="mouse",
         cage_id=Decimal("-99999999999999.0000000000"),
         room_id=Decimal("-99999999999999.0000000000"),
@@ -72,6 +73,8 @@ def test_labtracks_subject():
         ),
         group_name="Exp-ND-01-001-2109",
         group_description="BALB/c",
+        protocol_number="2116",
+        protocol_title="Mouse Breeding",
     )
 
 

--- a/aind-labtracks-service-server/tests/resources/test_db.json
+++ b/aind-labtracks-service-server/tests/resources/test_db.json
@@ -18,7 +18,7 @@
          "grant_id": "11574200",
          "ho_genetic_status": null,
          "class_values": "<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<MouseCustomClass xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <Reserved_by>Person A</Reserved_by>\r\n  <Reserve_Date>2022-07-14T00:00:00-07:00</Reserve_Date>\r\n  <Solution>1xPBS</Solution>\r\n  <Full_Genotype>Pvalb-IRES-Cre/wt;RCL-somBiPoles_mCerulean-WPRE/wt</Full_Genotype>\r\n  <Phenotype>P19: TSTW. Small body, large head, slightly dehydrated. 3.78g. P22: 5.59g. P26: 8.18g. Normal body proportions. </Phenotype>\r\n</MouseCustomClass>",
-         "acuc_link_id": "574197",
+         "acuc_link_id": "583474",
          "ho_new_genetic_line": null,
          "animal_class": "M",
          "species_id": "5",


### PR DESCRIPTION
closes https://github.com/AllenNeuralDynamics/aind-scientific-computing/issues/787

This PR: 
- Joins `IacucProtocol` table to subject view. Include `protocol_name` and `protocol_number` in response.
- Adds `death_date` from `AnimalsCommon` table because of a request from @dbirman 

Here is a sample response now: 
```
[
  {
    "id": "632269",
    "class_values": {
      "reserved_by": "Anna Lakunina",
      "reserved_date": "2022-07-14T00:00:00-07:00",
      "reason": null,
      "solution": "1xPBS",
      "full_genotype": "Pvalb-IRES-Cre/wt;RCL-somBiPoles_mCerulean-WPRE/wt",
      "phenotype": "P19: TSTW. Small body, large head, slightly dehydrated. 3.78g. P22: 5.59g. P26: 8.18g. Normal body proportions. "
    },
    "sex": "F",
    "birth_date": "2022-05-01T00:00:00",
    "death_date": "2022-10-14T00:00:00",
    "species_name": "mouse",
    "cage_id": "-99999999999999",
    "room_id": "-99999999999999",
    "paternal_id": "623236",
    "paternal_class_values": {
      "reserved_by": "Marie Desierto ",
      "reserved_date": "2022-11-01T00:00:00",
      "reason": "eu-retire",
      "solution": null,
      "full_genotype": "RCL-somBiPoles_mCerulean-WPRE/wt",
      "phenotype": "P87: F.G. P133: Barberer. "
    },
    "maternal_id": "615310",
    "maternal_class_values": {
      "reserved_by": "Marie Desierto ",
      "reserved_date": "2022-08-03T00:00:00",
      "reason": "Eu-retire",
      "solution": null,
      "full_genotype": "Pvalb-IRES-Cre/wt",
      "phenotype": "P100: F.G."
    },
    "group_name": "Exp-ND-01-001-2109",
    "group_description": null,
    "protocol_number": "2109",
    "protocol_title": "Analysis of brain-wide neural circuits in the mouse"
  }
]
```
@DowntonCrabby @dougollerenshaw Pls verify if this response is good or if more protocol info is needed
